### PR TITLE
Made instructions more newbie-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,26 @@ These images are currently intended for development use, not for production use.
 The Docker version of the [Confluent Quickstart](http://confluent.io/docs/current/quickstart.html)
 looks like this:
 
-    # Start Zookeeper
-    docker run -d --name zookeeper confluent/zookeeper
+    # Get the IP address of the docker machine
+    DOCKER_MACHINE=`boot2docker ip`
 
-    # Start Kafka
-    docker run -d --name kafka --link zookeeper:zookeeper confluent/kafka
+    # Start Zookeeper and expose port 2181 for use by the host machine
+    docker run -d --name zookeeper -p 2181:2181 confluent/zookeeper
 
-    # Start Schema Registry
-    docker run -d --name schema-registry --link zookeeper:zookeeper \
+    # Start Kafka and expose port 9092 for use by the host machine
+    # Also configure the broker to use the docker machine's IP address
+    docker run -d --name kafka -p 9092:9092 --link zookeeper:zookeeper \
+        --env KAFKA_ADVERTISED_HOST_NAME=$DOCKER_MACHINE confluent/kafka
+
+    # Start Schema Registry and expose port 8081 for use by the host machine
+    docker run -d --name schema-registry -p 8081:8081 --link zookeeper:zookeeper \
         --link kafka:kafka confluent/schema-registry
+
+If all goes well when you run the quickstart, `docker ps` should give you something that looks like this:
+
+    CONTAINER ID        IMAGE                              COMMAND                CREATED             STATUS              PORTS                    NAMES
+    4d33d52a98bd        confluent/schema-registry:latest   "/bin/sh -c /schema-   10 minutes ago      Up 10 minutes       0.0.0.0:8081->8081/tcp   schema-registry     
+    d9613d3bc37d        confluent/kafka:latest             "/bin/sh -c /kafka-d   10 minutes ago      Up 10 minutes       0.0.0.0:9092->9092/tcp   kafka               
+    459afcb7dfcf        confluent/zookeeper:latest         "/bin/sh -c '/usr/bi   10 minutes ago      Up 10 minutes       0.0.0.0:2181->2181/tcp   zookeeper           
+
+


### PR DESCRIPTION
Added arguments to expose ports to each docker run
Set the advertised.host.name environment variable correctly to ensure the producer and consumer talk to each other
Added sample docker.ps output to help troubleshooting