### PR TITLE
Version Kafka, Zookeeper, and Confluent platform independently. 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,6 +71,8 @@ for SCALA_VERSION in ${SCALA_VERSIONS}; do
     tar xzvf "./${STAGING_DIRECTORY}/${TAR_NAME}.tar.gz" -C "./${STAGING_DIRECTORY}/${TAR_NAME}"
     TAR_ROOT="$(find ${STAGING_DIRECTORY}/${TAR_NAME} -type d -maxdepth 1 -mindepth 1)"
 
+    find "${TAR_ROOT}" -name camus | xargs rm -rf
+
     ls -1 "${TAR_ROOT}/bin" | grep -v windows > "${TOOLS_COMMAND_LIST}"
 
     # Setup default configurations for kafka broker

--- a/build.sh
+++ b/build.sh
@@ -124,14 +124,36 @@ done <$TOOLS_COMMAND_LIST
 echo fi >> ./tools/confluent-tools.sh
 # end generate tools banner
 
-IMAGES="zookeeper kafka schema-registry rest-proxy tools"
 
-for IMAGE in ${IMAGES}; do
+
+CONFLUENT_IMAGES="schema-registry rest-proxy"
+
+for IMAGE in ${CONFLUENT_IMAGES}; do
   docker build $DOCKER_BUILD_OPTS -t "confluent/${IMAGE}:${CONFLUENT_PLATFORM_VERSION}" "${IMAGE}/"
   TAGS="${TAGS} confluent/${IMAGE}:${CONFLUENT_PLATFORM_VERSION}"
   docker tag $DOCKER_TAG_OPTS "confluent/${IMAGE}:${CONFLUENT_PLATFORM_VERSION}" "confluent/${IMAGE}:latest"
   TAGS="${TAGS} confluent/${IMAGE}:latest"
 done
+
+
+KAFKA_IMAGES="kafka tools"
+
+for IMAGE in ${KAFKA_IMAGES}; do
+  docker build $DOCKER_BUILD_OPTS -t "confluent/${IMAGE}:${KAFKA_VERSION}" "${IMAGE}/"
+  TAGS="${TAGS} confluent/${IMAGE}:${CONFLUENT_PLATFORM_VERSION}"
+  docker tag $DOCKER_TAG_OPTS "confluent/${IMAGE}:${KAFKA_VERSION}" "confluent/${IMAGE}:latest"
+  TAGS="${TAGS} confluent/${IMAGE}:latest"
+done
+
+ZOOKEEPER_IMAGES="zookeeper"
+
+for IMAGE in ${ZOOKEEPER_IMAGES}; do
+  docker build $DOCKER_BUILD_OPTS -t "confluent/${IMAGE}:${ZOOKEEPER_VERSION}" "${IMAGE}/"
+  TAGS="${TAGS} confluent/${IMAGE}:${CONFLUENT_PLATFORM_VERSION}"
+  docker tag $DOCKER_TAG_OPTS "confluent/${IMAGE}:${ZOOKEEPER_VERSION}" "confluent/${IMAGE}:latest"
+  TAGS="${TAGS} confluent/${IMAGE}:latest"
+done
+
 
 for TAG in ${TAGS}; do
   if [ "${PUSH_TO_DOCKER_HUB}" = "yes" ]; then

--- a/build.sh
+++ b/build.sh
@@ -71,8 +71,6 @@ for SCALA_VERSION in ${SCALA_VERSIONS}; do
     tar xzvf "./${STAGING_DIRECTORY}/${TAR_NAME}.tar.gz" -C "./${STAGING_DIRECTORY}/${TAR_NAME}"
     TAR_ROOT="$(find ${STAGING_DIRECTORY}/${TAR_NAME} -type d -maxdepth 1 -mindepth 1)"
 
-    find "${TAR_ROOT}" -name camus | xargs rm -rf
-
     ls -1 "${TAR_ROOT}/bin" | grep -v windows > "${TOOLS_COMMAND_LIST}"
 
     # Setup default configurations for kafka broker

--- a/settings.sh
+++ b/settings.sh
@@ -3,8 +3,8 @@
 : ${SCALA_VERSIONS:="2.10.5 2.11.7"}
 : ${DEFAULT_SCALA_VERSION:="2.11.7"}
 : ${CONFLUENT_PLATFORM_VERSION:="2.0.1"}
-: ${KAFKA_VERSION:="0.9.0.0-CP1"}
-: ${ZOOKEEPER_VERSION:="3.4.6-CP1"}
+: ${KAFKA_VERSION:="0.9.0.0-cp1"}
+: ${ZOOKEEPER_VERSION:="3.4.6-cp1"}
 : ${DOCKER_BUILD_OPTS:="--rm=true "}
 : ${DOCKER_TAG_OPTS:="-f "}
 : ${PACKAGE_URL:="http://packages.confluent.io/archive/2.0"}

--- a/settings.sh
+++ b/settings.sh
@@ -3,6 +3,8 @@
 : ${SCALA_VERSIONS:="2.10.5 2.11.7"}
 : ${DEFAULT_SCALA_VERSION:="2.11.7"}
 : ${CONFLUENT_PLATFORM_VERSION:="2.0.1"}
+: ${KAFKA_VERSION:="0.9.0.0-CP1"}
+: ${ZOOKEEPER_VERSION:="3.4.6-CP1"}
 : ${DOCKER_BUILD_OPTS:="--rm=true "}
 : ${DOCKER_TAG_OPTS:="-f "}
 : ${PACKAGE_URL:="http://packages.confluent.io/archive/2.0"}


### PR DESCRIPTION
This change allows you to configure the versions of the docker images independently. 

`CONFLUENT_PLATFORM_VERSION` configures the Confluent platform version.
`KAFKA_VERSION` controls the Kafka version. 
`ZOOKEEPER_VERSION` controls the zookeeper version.

Docker tags should look like this:

```
REPOSITORY                  TAG                 IMAGE ID            CREATED             SIZE
confluent/zookeeper         3.4.6-CP1           231c83716556        15 minutes ago      551.9 MB
confluent/zookeeper         latest              231c83716556        15 minutes ago      551.9 MB
confluent/tools             0.9.0.0-CP1         5980fc293a9b        15 minutes ago      551.9 MB
confluent/tools             latest              5980fc293a9b        15 minutes ago      551.9 MB
confluent/kafka             0.9.0.0-CP1         de8d9fb3a09e        15 minutes ago      551.9 MB
confluent/kafka             latest              de8d9fb3a09e        15 minutes ago      551.9 MB
confluent/rest-proxy        2.0.1               b9b31513a445        15 minutes ago      551.9 MB
confluent/rest-proxy        latest              b9b31513a445        15 minutes ago      551.9 MB
confluent/schema-registry   2.0.1               0776f0c3f3ca        15 minutes ago      551.9 MB
confluent/schema-registry   latest              0776f0c3f3ca        15 minutes ago      551.9 MB
confluent/platform-2.11.7   2.0.1               6d92a78092ad        15 minutes ago      551.9 MB
confluent/platform-2.11.7   latest              6d92a78092ad        15 minutes ago      551.9 MB
confluent/platform          2.0.1               6d92a78092ad        15 minutes ago      551.9 MB
confluent/platform          latest              6d92a78092ad        15 minutes ago      551.9 MB
confluent/platform-2.10.5   2.0.1               6865faaa77b7        15 minutes ago      554.1 MB
confluent/platform-2.10.5   latest              6865faaa77b7        15 minutes ago      554.1 MB
```