### PR TITLE
fix docker-compose

### DIFF
--- a/examples/fullstack/docker-compose.yml
+++ b/examples/fullstack/docker-compose.yml
@@ -1,40 +1,46 @@
 version: "2"
+
+
 services:
+
   zookeeper:
     image: confluent/zookeeper
     ports:
       - "2181:2181"
     environment:
       zk_id: "1"
-    network_mode: "host"
+
   kafka:
     image: confluent/kafka
-    depends_on:
-      - zookeeper
+    links:
+      - "zookeeper:zookeeper"
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "confluent:2181"
-    network_mode: "host"
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_ADVERTISED_HOST_NAME: "10.200.100.171"
+      KAFKA_ADVERTISED_PORT: "9092"
+
   rest-proxy:
     image: confluent/rest-proxy
-    depends_on:
-      - zookeeper
-      - kafka
-      - schema-registry
+    links:
+      - "zookeeper:zookeeper"
+      - "kafka:kafka"
+      - "schema-registry:schema-registry"
     ports:
       - "8082:8082"
     environment:
-      RP_ZOOKEEPER_CONNECT: "confluent:2181"
-      RP_SCHEMA_REGISTRY_URL: "http://confluent:8081"
-    network_mode: "host"
+      RP_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      RP_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+
   schema-registry:
     image: confluent/schema-registry
-    depends_on:
-      - kafka
-      - zookeeper
+    links:
+      - "kafka:zookeeper"
+      - "zookeeper:zookeeper"
     ports:
       - "8081:8081"
     environment:
-      SR_KAFKASTORE_CONNECTION_URL: "confluent:2181"
-    network_mode: "host"
+      SR_KAFKASTORE_CONNECTION_URL: "zookeeper:2181"
+
+##networks:

--- a/examples/fullstack/docker-compose.yml
+++ b/examples/fullstack/docker-compose.yml
@@ -12,35 +12,37 @@ services:
 
   kafka:
     image: confluent/kafka
-    links:
-      - "zookeeper:zookeeper"
+    depends_on:
+      - "zookeeper"
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_HOST_NAME: "10.200.100.171"
-      KAFKA_ADVERTISED_PORT: "9092"
+      KAFKA_ADVERTISED_HOST_NAME: "kafka"    #clients should resolve this to the docker host IP
+      #KAFKA_ADVERTISED_PORT: "9092"
+      #KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
 
   rest-proxy:
     image: confluent/rest-proxy
-    links:
-      - "zookeeper:zookeeper"
-      - "kafka:kafka"
-      - "schema-registry:schema-registry"
+    depends_on:
+      - "zookeeper"
+      - "kafka"
+      - "schema-registry"
     ports:
       - "8082:8082"
     environment:
-      RP_ZOOKEEPER_CONNECT: "zookeeper:2181"
       RP_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      #RP_ZOOKEEPER_CONNECT: "zookeeper:2181"
 
   schema-registry:
     image: confluent/schema-registry
-    links:
-      - "kafka:zookeeper"
-      - "zookeeper:zookeeper"
+    depends_on:
+      - "kafka"
+      - "zookeeper"
     ports:
       - "8081:8081"
     environment:
       SR_KAFKASTORE_CONNECTION_URL: "zookeeper:2181"
 
 ##networks:
+##    fullstack:
+


### PR DESCRIPTION
This updated docker-compose.yml file addresses issue #24 to set-up running on single node without breaking out of containers network namespace (net=host). 

Environment variables could be separated into env-files.
