### PR TITLE
Docker beta changes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,12 +11,6 @@ fi
 
 set -ex
 
-if [ -z ${DOCKER_HOST+x} ];
-then
-  echo "DOCKER_HOST must be set before running this script.";
-  exit 1
-fi
-
 mvn clean package
 
 TAGS=""

--- a/settings.sh
+++ b/settings.sh
@@ -6,7 +6,7 @@
 : ${KAFKA_VERSION:="0.10.0.0-cp1"}
 : ${ZOOKEEPER_VERSION:="3.4.6-cp1"}
 : ${DOCKER_BUILD_OPTS:="--rm=true "}
-: ${DOCKER_TAG_OPTS:="-f "}
+: ${DOCKER_TAG_OPTS:=""}
 : ${PACKAGE_URL:="http://packages.confluent.io/archive/3.0"}
 
 #PRIVATE_REPOSITORY=""


### PR DESCRIPTION
I'm running the Docker beta for Mac and these changes were required for the `build.sh` to work. 

I'm not really sure what the best way to go about making this backwards compatible, maybe a `DOCKER_VERSION` entry in `settings.sh` and a check for that along with the check for `DOCKER_HOST`?